### PR TITLE
Add Ruff linter

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,20 @@
+name: Lint
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install ruff
+      - name: Run ruff
+        run: ruff check .

--- a/custom_components/cozytouch/config_flow.py
+++ b/custom_components/cozytouch/config_flow.py
@@ -108,7 +108,9 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
-        # If there is no user input or there were errors, show the form again, including any errors that were found with the input.
+        # If there is no user input or there were errors,
+        # show the form again, including any errors that were found
+        # with the input.
         user_schema = vol.Schema(
             {vol.Required("username"): str, vol.Required("password"): str}
         )

--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -8,8 +8,10 @@ Mandatory :
 
 Optional :
     * currentTemperatureAvailable : enable current temperature availability (default : True)
-    * currentTemperatureAvailableZ1 : enable current temperature availability for Z1 (used for HEAT_PUMP, default : True)
-    * currentTemperatureAvailableZ2 : enable current temperature availability for Z2 (used for HEAT_PUMP, default : True)
+    * currentTemperatureAvailableZ1 : enable current temperature availability for
+      Z1 (used for HEAT_PUMP, default : True)
+    * currentTemperatureAvailableZ2 : enable current temperature availability for
+      Z2 (used for HEAT_PUMP, default : True)
     * exhaustTemperatureAvailable : enable exhaust temperature availability (default : True)
     * fanModes : list of value/mode pairs
     * swingModes : list of value/mode pairs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E501"]


### PR DESCRIPTION
## Summary
- add Ruff configuration with line-length 120
- break long lines in `config_flow.py` and `model.py`
- add lint workflow running Ruff

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68593f9aa22c832d8e2e097664e08c47