### PR TITLE
Fix unclosed sessions on unload

### DIFF
--- a/custom_components/cozytouch/__init__.py
+++ b/custom_components/cozytouch/__init__.py
@@ -56,6 +56,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        await hass.data[DOMAIN][entry.entry_id].close()
         hass.data[DOMAIN].pop(entry.entry_id)
 
     return unload_ok


### PR DESCRIPTION
## Summary
- close the hub session when unloading a config entry

## Testing
- `python -m py_compile custom_components/cozytouch/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_686ebef751f0832da04930194205e63c