### PR TITLE
Handle token refresh on unauthorized responses

### DIFF
--- a/custom_components/cozytouch/hub.py
+++ b/custom_components/cozytouch/hub.py
@@ -165,7 +165,9 @@ class Hub(DataUpdateCoordinator):
                             self._setup[key] = copy.deepcopy(json_data[0][key])
 
                     # Update devices infos
-                    await asyncio.get_event_loop().run_in_executor(None, self.update_devices_from_json_data, json_data)
+                    await asyncio.get_event_loop().run_in_executor(
+                        None, self.update_devices_from_json_data, json_data
+                    )
 
                     # Store country to retrieve localization informations
                     if "address" in json_data[0]:
@@ -284,7 +286,46 @@ class Hub(DataUpdateCoordinator):
                 headers=headers,
             ) as response:
                 try:
-                    json_data = await response.json()
+                    if response.status in (401, 403):
+                        _LOGGER.info("Token invalid, trying to refresh")
+                        await self.connect()
+                        if not self.online:
+                            return
+                        headers = {
+                            "Authorization": f"Bearer {self._access_token}",
+                            "Content-Type": "application/json",
+                        }
+                        async with self._session.get(
+                            COZYTOUCH_ATLANTIC_API
+                            + "/magellan/capabilities/?deviceId="
+                            + str(self._deviceId),
+                            headers=headers,
+                        ) as retry_response:
+                            response = retry_response
+                            json_data = await response.json()
+                    else:
+                        json_data = await response.json()
+                        if (
+                            isinstance(json_data, dict)
+                            and json_data.get("error") == "invalid_grant"
+                        ):
+                            _LOGGER.info("Token invalid_grant, trying to refresh")
+                            await self.connect()
+                            if not self.online:
+                                return
+                            headers = {
+                                "Authorization": f"Bearer {self._access_token}",
+                                "Content-Type": "application/json",
+                            }
+                            async with self._session.get(
+                                COZYTOUCH_ATLANTIC_API
+                                + "/magellan/capabilities/?deviceId="
+                                + str(self._deviceId),
+                                headers=headers,
+                            ) as retry_response:
+                                response = retry_response
+                                json_data = await response.json()
+
                     if not isinstance(json_data, list):
                         _LOGGER.warning(
                             "Invalid capabilities response for device %s: %s",

--- a/tests/test_token_refresh.py
+++ b/tests/test_token_refresh.py
@@ -1,0 +1,175 @@
+import os
+import sys
+import pytest
+import types
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+ha_core = types.ModuleType("homeassistant.core")
+ha_core.HomeAssistant = type("HomeAssistant", (), {})
+
+ha_helpers_dev_reg = types.ModuleType("homeassistant.helpers.device_registry")
+ha_helpers_dev_reg.DeviceEntryType = type("DeviceEntryType", (), {"SERVICE": "service"})
+ha_helpers_dev_reg.DeviceInfo = type("DeviceInfo", (), {})
+
+ha_exceptions = types.ModuleType("homeassistant.exceptions")
+ha_exceptions.HomeAssistantError = Exception
+
+ha_config_entries = types.ModuleType("homeassistant.config_entries")
+ha_config_entries.ConfigEntry = type("ConfigEntry", (), {})
+
+ha_helpers_update = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+
+class DummyCoordinator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+ha_helpers_update.DataUpdateCoordinator = DummyCoordinator
+
+ha_util_dt = types.ModuleType("homeassistant.util.dt")
+from datetime import timezone
+
+ha_util_dt.DEFAULT_TIME_ZONE = timezone.utc
+
+sys.modules["homeassistant"] = types.ModuleType("homeassistant")
+sys.modules["homeassistant.core"] = ha_core
+sys.modules["homeassistant.helpers"] = types.ModuleType("homeassistant.helpers")
+sys.modules["homeassistant.helpers.device_registry"] = ha_helpers_dev_reg
+sys.modules["homeassistant.helpers.update_coordinator"] = ha_helpers_update
+sys.modules["homeassistant.exceptions"] = ha_exceptions
+sys.modules["homeassistant.config_entries"] = ha_config_entries
+sys.modules["homeassistant.util"] = types.ModuleType("homeassistant.util")
+sys.modules["homeassistant.util.dt"] = ha_util_dt
+
+from importlib.machinery import SourceFileLoader
+from importlib import util
+
+hub_path = os.path.abspath(
+    os.path.join(
+        os.path.dirname(__file__), "..", "custom_components", "cozytouch", "hub.py"
+    )
+)
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+
+cozy_pkg = types.ModuleType("custom_components.cozytouch")
+cozy_pkg.__path__ = [os.path.dirname(hub_path)]
+sys.modules["custom_components.cozytouch"] = cozy_pkg
+stub_cap = types.ModuleType("custom_components.cozytouch.capability")
+stub_cap.get_capability_infos = lambda *a, **k: {}
+sys.modules["custom_components.cozytouch.capability"] = stub_cap
+stub_model = types.ModuleType("custom_components.cozytouch.model")
+stub_model.get_model_infos = lambda *a, **k: {}
+sys.modules["custom_components.cozytouch.model"] = stub_model
+
+spec = util.spec_from_loader(
+    "custom_components.cozytouch.hub",
+    SourceFileLoader("custom_components.cozytouch.hub", hub_path),
+    origin=hub_path,
+)
+hub_module = util.module_from_spec(spec)
+sys.modules[spec.name] = hub_module
+spec.loader.exec_module(hub_module)
+Hub = hub_module.Hub
+
+
+class DummyConfig:
+    config_dir = "/tmp"
+
+
+class DummyHass:
+    config = DummyConfig()
+
+
+class MockResponse:
+    def __init__(self, status, data):
+        self.status = status
+        self._data = data
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        return self._data
+
+
+@pytest.mark.asyncio
+async def test_refresh_on_401(monkeypatch):
+    hass = DummyHass()
+    hub = Hub(hass, "u", "p", deviceId=1)
+    hub.online = True
+    hub._access_token = "tok"
+    hub._devices = [
+        {
+            "deviceId": 1,
+            "name": "dev",
+            "modelId": 0,
+            "gatewaySerialNumber": "sn",
+            "productId": 0,
+            "zoneId": 0,
+            "modelInfos": {},
+            "capabilities": [],
+        }
+    ]
+
+    calls = []
+
+    async def mock_connect():
+        calls.append(True)
+        hub.online = True
+
+    monkeypatch.setattr(hub, "connect", mock_connect)
+
+    responses = [MockResponse(401, {}), MockResponse(200, [])]
+
+    def mock_get(*args, **kwargs):
+        return responses.pop(0)
+
+    hub._session.get = mock_get
+
+    await hub._async_update_data()
+    await hub.close()
+    assert calls
+
+
+@pytest.mark.asyncio
+async def test_refresh_on_invalid_grant(monkeypatch):
+    hass = DummyHass()
+    hub = Hub(hass, "u", "p", deviceId=1)
+    hub.online = True
+    hub._access_token = "tok"
+    hub._devices = [
+        {
+            "deviceId": 1,
+            "name": "dev",
+            "modelId": 0,
+            "gatewaySerialNumber": "sn",
+            "productId": 0,
+            "zoneId": 0,
+            "modelInfos": {},
+            "capabilities": [],
+        }
+    ]
+
+    calls = []
+
+    async def mock_connect():
+        calls.append(True)
+        hub.online = True
+
+    monkeypatch.setattr(hub, "connect", mock_connect)
+
+    responses = [MockResponse(200, {"error": "invalid_grant"}), MockResponse(200, [])]
+
+    def mock_get(*args, **kwargs):
+        return responses.pop(0)
+
+    hub._session.get = mock_get
+
+    await hub._async_update_data()
+    await hub.close()
+    assert calls


### PR DESCRIPTION
## Summary
- detect 401/403 and invalid_grant in hub update method
- refresh token and retry when unauthorized
- log token refresh attempts
- add tests for token refresh behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ebef86b04832d86fb457f530b895c