### PR TITLE
Add additional device models

### DIFF
--- a/custom_components/cozytouch/model.py
+++ b/custom_components/cozytouch/model.py
@@ -206,7 +206,7 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
             8: HVACMode.DRY,
         }
 
-    elif modelId >= 562 and modelId <= 566:
+    elif modelId >= 562 and modelId <= 570:
         name = "Air Conditioner User Interface "
         if zoneName is not None:
             modelInfos["name"] = name + "(" + zoneName + ")"
@@ -306,7 +306,15 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
         modelInfos["HVACModes"] = {
             0: HVACMode.OFF,
             4: HVACMode.HEAT,
-    }
+        }
+
+    elif modelId == 1551:
+        modelInfos["name"] = "Asama Connecté II Ventilo 1750W Noir"
+        modelInfos["type"] = CozytouchDeviceType.TOWEL_RACK
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
+            4: HVACMode.HEAT,
+        }
 
     elif modelId == 1622:
         modelInfos["name"] = "Thermor Riva 5"
@@ -314,6 +322,20 @@ def get_model_infos(modelId: int, zoneName: str | None = None):
         modelInfos["HVACModes"] = {
             0: HVACMode.OFF,
             4: HVACMode.HEAT,
+        }
+
+    elif modelId == 1656:
+        modelInfos["name"] = "Aeromax 6"
+        modelInfos["type"] = CozytouchDeviceType.WATER_HEATER
+        modelInfos["HVACModes"] = {
+            0: HVACMode.OFF,
+            4: HVACMode.HEAT,
+        }
+
+        modelInfos["HeatingModes"] = {
+            0: HEATING_MODE_MANUAL,
+            3: HEATING_MODE_ECO_PLUS,
+            4: HEATING_MODE_PROG,
         }
 
     else:

--- a/tests/test_hub_connect.py
+++ b/tests/test_hub_connect.py
@@ -2,11 +2,84 @@ import os
 import sys
 import pytest
 from aiohttp import ContentTypeError
+import types
+
+ha_core = types.ModuleType("homeassistant.core")
+
+class StubHomeAssistant:
+    def __init__(self, *args, **kwargs):
+        pass
+
+ha_core.HomeAssistant = StubHomeAssistant
+
+ha_helpers_dev_reg = types.ModuleType("homeassistant.helpers.device_registry")
+ha_helpers_dev_reg.DeviceEntryType = type("DeviceEntryType", (), {"SERVICE": "service"})
+ha_helpers_dev_reg.DeviceInfo = type("DeviceInfo", (), {})
+
+ha_exceptions = types.ModuleType("homeassistant.exceptions")
+ha_exceptions.HomeAssistantError = Exception
+
+ha_config_entries = types.ModuleType("homeassistant.config_entries")
+ha_config_entries.ConfigEntry = type("ConfigEntry", (), {})
+
+ha_helpers_update = types.ModuleType("homeassistant.helpers.update_coordinator")
+
+
+class DummyCoordinator:
+    def __init__(self, *args, **kwargs):
+        pass
+
+
+ha_helpers_update.DataUpdateCoordinator = DummyCoordinator
+
+ha_util_dt = types.ModuleType("homeassistant.util.dt")
+from datetime import timezone
+
+ha_util_dt.DEFAULT_TIME_ZONE = timezone.utc
+
+sys.modules["homeassistant"] = types.ModuleType("homeassistant")
+sys.modules["homeassistant.core"] = ha_core
+sys.modules["homeassistant.helpers"] = types.ModuleType("homeassistant.helpers")
+sys.modules["homeassistant.helpers.device_registry"] = ha_helpers_dev_reg
+sys.modules["homeassistant.helpers.update_coordinator"] = ha_helpers_update
+sys.modules["homeassistant.exceptions"] = ha_exceptions
+sys.modules["homeassistant.config_entries"] = ha_config_entries
+sys.modules["homeassistant.util"] = types.ModuleType("homeassistant.util")
+sys.modules["homeassistant.util.dt"] = ha_util_dt
+
 from homeassistant.core import HomeAssistant
+
+from importlib.machinery import SourceFileLoader
+from importlib import util
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from custom_components.cozytouch.hub import Hub, CannotConnect
+hub_path = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "custom_components", "cozytouch", "hub.py")
+)
+
+sys.modules.setdefault("custom_components", types.ModuleType("custom_components"))
+
+cozy_pkg = types.ModuleType("custom_components.cozytouch")
+cozy_pkg.__path__ = [os.path.dirname(hub_path)]
+sys.modules["custom_components.cozytouch"] = cozy_pkg
+stub_cap = types.ModuleType("custom_components.cozytouch.capability")
+stub_cap.get_capability_infos = lambda *a, **k: {}
+sys.modules["custom_components.cozytouch.capability"] = stub_cap
+stub_model = types.ModuleType("custom_components.cozytouch.model")
+stub_model.get_model_infos = lambda *a, **k: {}
+sys.modules["custom_components.cozytouch.model"] = stub_model
+
+spec = util.spec_from_loader(
+    "custom_components.cozytouch.hub",
+    SourceFileLoader("custom_components.cozytouch.hub", hub_path),
+    origin=hub_path,
+)
+hub_module = util.module_from_spec(spec)
+sys.modules[spec.name] = hub_module
+spec.loader.exec_module(hub_module)
+Hub = hub_module.Hub
+CannotConnect = hub_module.CannotConnect
 
 class FakeResponse:
     def __init__(self, status=200, json_data=None, exc=None):


### PR DESCRIPTION
## Summary
- extend AC UI range to 570
- add support for model 1551 (Asama Connecté II Ventilo 1750W Noir)
- add support for model 1656 (Aeromax 6)
- update hub connect tests to run without Home Assistant

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ed1d9265c832da942f7ff76b435d7